### PR TITLE
[BUG_FIX] Rate limit bypass 

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ module.exports = {
 				return next();
 
 			// req.ip gives you the true proxied ip. id is combination of ip and req path
-			var id = req.ip + '_' + req.path;
+			var id = req.ip + '_' + req.path.toLowerCase();
 			// 15 requests are allowed in 2 minute.
 			var limit = new ratelimiter({ id: id, db: redis_db, max: 15, duration: 120000 });
 			limit.get(function (err, limit) {


### PR DESCRIPTION
To prevent ratelimit bypass by uppercase lowercase combinations in route path, added toLower to path id to uniquely identify routes and mitigate this issue 